### PR TITLE
Adds equal sign filtering from airbrake errors to make error grouping work for S3 errors

### DIFF
--- a/errors_reporting.go
+++ b/errors_reporting.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/pkg/errors"
 	"net/http"
 	"strings"
 	"time"
@@ -93,6 +94,10 @@ func reportError(err error, req *http.Request) {
 	}
 
 	if airbrakeEnabled {
-		airbrake.Notify(err, req)
+		// airbrake won't group like errors together if they have and equal sign
+		// S3 errors especially have this issue with a trailing = on the host id
+		cleanErrStr := strings.Replace(err.Error(), "=", "", -1)
+		cleanErr := errors.New(cleanErrStr)
+		airbrake.Notify(cleanErr, req)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,9 @@ require (
 	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bugsnag/bugsnag-go/v2 v2.1.1
-	github.com/bugsnag/panicwrap v1.2.2 // indirect
 	github.com/getsentry/sentry-go v0.10.0
 	github.com/go-ole/go-ole v1.2.4 // indirect
-	github.com/gofrs/uuid v3.3.0+incompatible // indirect
+	github.com/google/uuid v1.1.2
 	github.com/honeybadger-io/honeybadger-go v0.5.0
 	github.com/ianlancetaylor/cgosymbolizer v0.0.0-20201204192058-7acc97e53614 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
@@ -29,7 +28,7 @@ require (
 	golang.org/x/sys v0.0.0-20210503080704-8803ae5d1324
 	golang.org/x/text v0.3.6
 	google.golang.org/api v0.46.0
-        github.com/google/uuid v1.1.2
+	github.com/pkg/errors v0.9.1
 )
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bugsnag/bugsnag-go/v2 v2.1.1 h1:/X6xB3DvfMCNOSopEvGkOpDSk0iTq4yBSp7SkiV7nM8=
 github.com/bugsnag/bugsnag-go/v2 v2.1.1/go.mod h1:XEgTxTSo37lM/jpzZY9a8FJgJCqZMEagthLA6TSDl+o=
+github.com/bugsnag/panicwrap v1.2.2/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bugsnag/panicwrap v1.3.2 h1:pNcbtPtH4Y6VwK+oZVNV/2H6Hh3jOL0ZNVFZEfd/eA4=
 github.com/bugsnag/panicwrap v1.3.2/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/caio/go-tdigest v3.1.0+incompatible h1:uoVMJ3Q5lXmVLCCqaMGHLBWnbGoN6Lpu7OAUPR60cds=
@@ -188,6 +189,7 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=


### PR DESCRIPTION
For example the error message below.

> Get "s3://s3-bucket/image.jpg": InvalidObjectState: The operation is not valid for the object's storage class status code: 403, request id: K5K6T5W21UD13TRK, host id: n4HEQ3WabkFpeOTWlqvspE83ORhiP2mLLxiaj4tIkbYB9U1he8QgkEqHFcQp4jD2Xewf8Np2vNI=

The equal sign at the end gets interpreted as meaning n4HEQ3WabkFpeOTWlqvspE83ORhiP2mLLxiaj4tIkbYB9U1he8QgkEqHFcQp4jD2Xewf8Np2vNI is a unique key and none of these messages get grouped together.