### PR TITLE
Fixes Bmp negative height bug

### DIFF
--- a/imagemeta/bmp.go
+++ b/imagemeta/bmp.go
@@ -33,7 +33,7 @@ func DecodeBmpMeta(r io.Reader) (Meta, error) {
 	} else {
 		// CORE
 		width = int(binary.LittleEndian.Uint16(tmp[18:20]))
-		height = int(binary.LittleEndian.Uint16(tmp[20:22]))
+		height = int(int16(binary.LittleEndian.Uint16(tmp[20:22])))
 	}
 
 	// height can be negative in Windows bitmaps

--- a/imagemeta/bmp.go
+++ b/imagemeta/bmp.go
@@ -29,7 +29,13 @@ func DecodeBmpMeta(r io.Reader) (Meta, error) {
 
 	if infoSize >= 40 {
 		width = int(binary.LittleEndian.Uint32(tmp[18:22]))
-		height = int(binary.LittleEndian.Uint32(tmp[22:26]))
+		signedHeight := int32(binary.LittleEndian.Uint32(tmp[22:26]))
+		// height can be negative in Windows bitmaps
+		if signedHeight < 0 {
+			height = int(-signedHeight)
+		} else {
+			height = int(signedHeight)
+		}
 	} else {
 		// CORE
 		width = int(binary.LittleEndian.Uint16(tmp[18:20]))

--- a/imagemeta/bmp.go
+++ b/imagemeta/bmp.go
@@ -29,17 +29,16 @@ func DecodeBmpMeta(r io.Reader) (Meta, error) {
 
 	if infoSize >= 40 {
 		width = int(binary.LittleEndian.Uint32(tmp[18:22]))
-		signedHeight := int32(binary.LittleEndian.Uint32(tmp[22:26]))
-		// height can be negative in Windows bitmaps
-		if signedHeight < 0 {
-			height = int(-signedHeight)
-		} else {
-			height = int(signedHeight)
-		}
+		height = int(int32(binary.LittleEndian.Uint32(tmp[22:26])))
 	} else {
 		// CORE
 		width = int(binary.LittleEndian.Uint16(tmp[18:20]))
 		height = int(binary.LittleEndian.Uint16(tmp[20:22]))
+	}
+
+	// height can be negative in Windows bitmaps
+	if height < 0 {
+		height = -height
 	}
 
 	return &meta{


### PR DESCRIPTION
Bmp files can have negative height values, which are currently calculated as super giant, and are therefore not rendered. This fixes that.

This change is already merged upstream.