### PR TITLE
Background Blur Support

### DIFF
--- a/process.go
+++ b/process.go
@@ -356,7 +356,6 @@ func transformImage(ctx context.Context, img *vipsImage, data []byte, po *proces
 	heightToScale := minNonZeroInt(cropHeight, srcHeight)
 
 	scale := calcScale(widthToScale, heightToScale, po, imgtype)
-	preLoadScale := scale
 
 	if cropWidth > 0 {
 		cropWidth = maxInt(1, scaleInt(cropWidth, scale))
@@ -550,63 +549,11 @@ func transformImage(ctx context.Context, img *vipsImage, data []byte, po *proces
 
 			// Make a copy of the image for embedding later
 			centerImage := new(vipsImage)
-			centerScale := preLoadScale
 
 			// Load the second copy and reapply transformations that effect the size/shape
 			// of the image.
-			// TODO: Refactor so this is shared with the earlier version
-			if !trimmed && centerScale != 1 && data != nil && canScaleOnLoad(imgtype, centerScale) {
-				jpegShrink := calcJpegShink(centerScale, imgtype)
-
-				if imgtype != imageTypeJPEG || jpegShrink != 1 {
-					// Do some scale-on-load
-					if err = centerImage.Load(data, imgtype, jpegShrink, centerScale, 1); err != nil {
-						return err
-					}
-				}
-
-				// Update scale after scale-on-load
-				newWidth, newHeight, _, _ := extractMeta(centerImage, po.Rotate, po.AutoRotate)
-				if srcWidth > srcHeight {
-					centerScale = float64(srcWidth) * centerScale / float64(newWidth)
-				} else {
-					centerScale = float64(srcHeight) * centerScale / float64(newHeight)
-				}
-				if srcWidth == scaleInt(srcWidth, centerScale) && srcHeight == scaleInt(srcHeight, scale) {
-					centerScale = 1.0
-				}
-			}
-
-			if centerScale != 1 {
-				if err = centerImage.Resize(centerScale, hasAlpha); err != nil {
-					return err
-				}
-			}
-
-			if err = copyMemoryAndCheckTimeout(ctx, centerImage); err != nil {
-				return err
-			}
-
-			if err = centerImage.Rotate(angle); err != nil {
-				return err
-			}
-
-			if flip {
-				if err = centerImage.Flip(); err != nil {
-					return err
-				}
-			}
-
-			if err = centerImage.Rotate(po.Rotate); err != nil {
-				return err
-			}
-			if err = cropImage(centerImage, cropWidth, cropHeight, &cropGravity); err != nil {
-				return err
-			}
-			if err = cropImage(centerImage, dprWidth, dprHeight, &po.Gravity); err != nil {
-				return err
-			}
-			// end transforms
+			// TODO: Refactor the earlier transform code to share this
+			loadAndTransform(ctx, centerImage, data, po, imgtype, srcWidth, srcHeight, angle, flip)
 
 			// Resize to the image area and then center smart crop to trim off excess.
 			outputScale := math.Max((float64(outputWidth) / float64(img.Width())), (float64(outputHeight) / float64(img.Height())))
@@ -673,6 +620,97 @@ func transformImage(ctx context.Context, img *vipsImage, data []byte, po *proces
 	}
 
 	return copyMemoryAndCheckTimeout(ctx, img)
+}
+
+func loadAndTransform(ctx context.Context,
+	img *vipsImage,
+	data []byte,
+	po *processingOptions,
+	imgtype imageType,
+	srcWidth int,
+	srcHeight int,
+	angle int,
+	flip bool) error {
+	var err error
+
+	cropWidth := calcCropSize(srcWidth, po.Crop.Width)
+	cropHeight := calcCropSize(srcHeight, po.Crop.Height)
+
+	cropGravity := po.Crop.Gravity
+	if cropGravity.Type == gravityUnknown {
+		cropGravity = po.Gravity
+	}
+
+	widthToScale := minNonZeroInt(cropWidth, srcWidth)
+	heightToScale := minNonZeroInt(cropHeight, srcHeight)
+
+	scale := calcScale(widthToScale, heightToScale, po, imgtype)
+	dprWidth := scaleInt(po.Width, po.Dpr)
+	dprHeight := scaleInt(po.Height, po.Dpr)
+
+	if cropWidth > 0 {
+		cropWidth = maxInt(1, scaleInt(cropWidth, scale))
+	}
+	if cropHeight > 0 {
+		cropHeight = maxInt(1, scaleInt(cropHeight, scale))
+	}
+	if cropGravity.Type != gravityFocusPoint {
+		cropGravity.X *= scale
+		cropGravity.Y *= scale
+	}
+
+	if scale != 1 && data != nil && canScaleOnLoad(imgtype, scale) {
+		jpegShrink := calcJpegShink(scale, imgtype)
+
+		if imgtype != imageTypeJPEG || jpegShrink != 1 {
+			// Do some scale-on-load
+			if err = img.Load(data, imgtype, jpegShrink, scale, 1); err != nil {
+				return err
+			}
+		}
+
+		// Update scale after scale-on-load
+		newWidth, newHeight, _, _ := extractMeta(img, po.Rotate, po.AutoRotate)
+		if srcWidth > srcHeight {
+			scale = float64(srcWidth) * scale / float64(newWidth)
+		} else {
+			scale = float64(srcHeight) * scale / float64(newHeight)
+		}
+		if srcWidth == scaleInt(srcWidth, scale) && srcHeight == scaleInt(srcHeight, scale) {
+			scale = 1.0
+		}
+	}
+
+	if scale != 1 {
+		if err = img.Resize(scale, img.HasAlpha()); err != nil {
+			return err
+		}
+	}
+
+	if err = copyMemoryAndCheckTimeout(ctx, img); err != nil {
+		return err
+	}
+
+	if err = img.Rotate(angle); err != nil {
+		return err
+	}
+
+	if flip {
+		if err = img.Flip(); err != nil {
+			return err
+		}
+	}
+
+	if err = img.Rotate(po.Rotate); err != nil {
+		return err
+	}
+	if err = cropImage(img, cropWidth, cropHeight, &cropGravity); err != nil {
+		return err
+	}
+	if err = cropImage(img, dprWidth, dprHeight, &po.Gravity); err != nil {
+		return err
+	}
+	return nil
 }
 
 func transformAnimated(ctx context.Context, img *vipsImage, data []byte, po *processingOptions, imgtype imageType) error {

--- a/process.go
+++ b/process.go
@@ -549,6 +549,7 @@ func transformImage(ctx context.Context, img *vipsImage, data []byte, po *proces
 
 			// Make a copy of the image for embedding later
 			centerImage := new(vipsImage)
+			defer centerImage.Clear()
 
 			// Load the second copy and reapply transformations that effect the size/shape
 			// of the image.
@@ -665,6 +666,11 @@ func loadAndTransform(ctx context.Context,
 		if imgtype != imageTypeJPEG || jpegShrink != 1 {
 			// Do some scale-on-load
 			if err = img.Load(data, imgtype, jpegShrink, scale, 1); err != nil {
+				return err
+			}
+		} else {
+			// No scale-on-load
+			if err := img.Load(data, imgtype, 1, 1.0, 1); err != nil {
 				return err
 			}
 		}

--- a/process.go
+++ b/process.go
@@ -553,7 +553,6 @@ func transformImage(ctx context.Context, img *vipsImage, data []byte, po *proces
 
 			// Load the second copy and reapply transformations that effect the size/shape
 			// of the image.
-			// TODO: Refactor the earlier transform code to share this
 			loadAndTransform(ctx, centerImage, data, po, imgtype, srcWidth, srcHeight, angle, flip)
 
 			// Resize to the image area and then center smart crop to trim off excess.

--- a/processing_options.go
+++ b/processing_options.go
@@ -117,6 +117,11 @@ type trimOptions struct {
 	EqualVer  bool
 }
 
+type backgroundOptions struct {
+	Color  rgbColor
+	Effect string
+}
+
 type watermarkOptions struct {
 	Enabled   bool
 	Opacity   float64
@@ -141,7 +146,7 @@ type processingOptions struct {
 	Quality           int
 	MaxBytes          int
 	Flatten           bool
-	Background        rgbColor
+	Background        backgroundOptions
 	Blur              float32
 	Sharpen           float32
 	StripMetadata     bool
@@ -229,7 +234,7 @@ func newProcessingOptions() *processingOptions {
 			Quality:           0,
 			MaxBytes:          0,
 			Format:            imageTypeUnknown,
-			Background:        rgbColor{255, 255, 255},
+			Background:        backgroundOptions{Color: rgbColor{255, 255, 255}},
 			Blur:              0,
 			Sharpen:           0,
 			Dpr:               1,
@@ -721,7 +726,12 @@ func applyBackgroundOption(po *processingOptions, args []string) error {
 			po.Flatten = false
 		} else if c, err := colorFromHex(args[0]); err == nil {
 			po.Flatten = true
-			po.Background = c
+			po.Background.Color = c
+		} else if args[0] == "blur" {
+			po.Flatten = true
+			po.Background.Effect = "blur"
+			// Test hack
+			po.Background.Color = rgbColor{255, 0, 0}
 		} else {
 			return fmt.Errorf("Invalid background argument: %s", err)
 		}
@@ -730,19 +740,19 @@ func applyBackgroundOption(po *processingOptions, args []string) error {
 		po.Flatten = true
 
 		if r, err := strconv.ParseUint(args[0], 10, 8); err == nil && r <= 255 {
-			po.Background.R = uint8(r)
+			po.Background.Color.R = uint8(r)
 		} else {
 			return fmt.Errorf("Invalid background red channel: %s", args[0])
 		}
 
 		if g, err := strconv.ParseUint(args[1], 10, 8); err == nil && g <= 255 {
-			po.Background.G = uint8(g)
+			po.Background.Color.G = uint8(g)
 		} else {
 			return fmt.Errorf("Invalid background green channel: %s", args[1])
 		}
 
 		if b, err := strconv.ParseUint(args[2], 10, 8); err == nil && b <= 255 {
-			po.Background.B = uint8(b)
+			po.Background.Color.B = uint8(b)
 		} else {
 			return fmt.Errorf("Invalid background blue channel: %s", args[2])
 		}

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -307,9 +307,9 @@ func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedBackground() {
 
 	po := getProcessingOptions(ctx)
 	assert.True(s.T(), po.Flatten)
-	assert.Equal(s.T(), uint8(128), po.Background.R)
-	assert.Equal(s.T(), uint8(129), po.Background.G)
-	assert.Equal(s.T(), uint8(130), po.Background.B)
+	assert.Equal(s.T(), uint8(128), po.Background.Color.R)
+	assert.Equal(s.T(), uint8(129), po.Background.Color.G)
+	assert.Equal(s.T(), uint8(130), po.Background.Color.B)
 }
 
 func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedBackgroundHex() {
@@ -320,9 +320,20 @@ func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedBackgroundHex() {
 
 	po := getProcessingOptions(ctx)
 	assert.True(s.T(), po.Flatten)
-	assert.Equal(s.T(), uint8(0xff), po.Background.R)
-	assert.Equal(s.T(), uint8(0xdd), po.Background.G)
-	assert.Equal(s.T(), uint8(0xee), po.Background.B)
+	assert.Equal(s.T(), uint8(0xff), po.Background.Color.R)
+	assert.Equal(s.T(), uint8(0xdd), po.Background.Color.G)
+	assert.Equal(s.T(), uint8(0xee), po.Background.Color.B)
+}
+
+func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedBackgroundEffect() {
+	req := s.getRequest("/unsafe/background:blur/plain/http://images.dev/lorem/ipsum.jpg")
+	ctx, err := parsePath(context.Background(), req)
+
+	require.Nil(s.T(), err)
+
+	po := getProcessingOptions(ctx)
+	assert.True(s.T(), po.Flatten)
+	assert.Equal(s.T(), "blur", po.Background.Effect)
 }
 
 func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedBackgroundDisable() {

--- a/vips.c
+++ b/vips.c
@@ -575,12 +575,23 @@ vips_embed_go(VipsImage *in, VipsImage **out, int x, int y, int width, int heigh
 }
 
 int
+vips_embed_image_go(VipsImage *in, VipsImage *sub, VipsImage **out, int x, int y, gboolean expand) {
+  int ret = vips_insert(in, sub, out, x, y, "expand", expand, NULL);
+  return ret;
+}
+
+int
 vips_ensure_alpha(VipsImage *in, VipsImage **out) {
   if (vips_image_hasalpha_go(in)) {
     return vips_copy(in, out, NULL);
   }
 
   return vips_bandjoin_const1(in, out, 255, NULL);
+}
+
+int
+vips_color_adjust(VipsImage *in, VipsImage **out, double scale) {
+  return vips_linear1(in, out, scale, 0, NULL);
 }
 
 int

--- a/vips.c
+++ b/vips.c
@@ -446,6 +446,16 @@ vips_smartcrop_go(VipsImage *in, VipsImage **out, int width, int height) {
 }
 
 int
+vips_smartcrop_center_go(VipsImage *in, VipsImage **out, int width, int height) {
+#if VIPS_SUPPORT_SMARTCROP
+  return vips_smartcrop(in, out, width, height, "interesting", VIPS_INTERESTING_CENTRE, NULL);
+#else
+  vips_error("vips_smartcrop_center_go", "Smart crop is not supported (libvips 8.5+ reuired)");
+  return 1;
+#endif
+}
+
+int
 vips_gaussblur_go(VipsImage *in, VipsImage **out, double sigma) {
   return vips_gaussblur(in, out, sigma, NULL);
 }

--- a/vips.go
+++ b/vips.go
@@ -496,6 +496,17 @@ func (img *vipsImage) SmartCrop(width, height int) error {
 	return nil
 }
 
+func (img *vipsImage) CenterFill(width, height int) error {
+	var tmp *C.VipsImage
+
+	if C.vips_smartcrop_center_go(img.VipsImage, &tmp, C.int(width), C.int(height)) != 0 {
+		return vipsError()
+	}
+
+	C.swap_and_clear(&img.VipsImage, tmp)
+	return nil
+}
+
 func (img *vipsImage) Trim(threshold float64, smart bool, color rgbColor, equalHor bool, equalVer bool) error {
 	var tmp *C.VipsImage
 

--- a/vips.go
+++ b/vips.go
@@ -408,6 +408,17 @@ func (img *vipsImage) Rad2Float() error {
 	return nil
 }
 
+func (img *vipsImage) ColorAdjust(scale float64) error {
+	var tmp *C.VipsImage
+	if C.vips_color_adjust(img.VipsImage, &tmp, C.double(scale)) != 0 {
+		return vipsError()
+	}
+
+	C.swap_and_clear(&img.VipsImage, tmp)
+
+	return nil
+}
+
 func (img *vipsImage) Resize(scale float64, hasAlpa bool) error {
 	var tmp *C.VipsImage
 
@@ -698,6 +709,21 @@ func (img *vipsImage) Embed(width, height int, offX, offY int, bg rgbColor, tran
 	bgn := minInt(int(img.VipsImage.Bands), len(bgc))
 
 	if C.vips_embed_go(img.VipsImage, &tmp, C.int(offX), C.int(offY), C.int(width), C.int(height), &bgc[0], C.int(bgn)) != 0 {
+		return vipsError()
+	}
+	C.swap_and_clear(&img.VipsImage, tmp)
+
+	return nil
+}
+
+func (img *vipsImage) EmbedImage(offX, offY int, sub *vipsImage) error {
+	var tmp *C.VipsImage
+
+	if err := img.RgbColourspace(); err != nil {
+		return err
+	}
+
+	if C.vips_embed_image_go(img.VipsImage, sub.VipsImage, &tmp, C.int(offX), C.int(offY), gbool(true)) != 0 {
 		return vipsError()
 	}
 	C.swap_and_clear(&img.VipsImage, tmp)

--- a/vips.h
+++ b/vips.h
@@ -75,6 +75,7 @@ int vips_flip_horizontal_go(VipsImage *in, VipsImage **out);
 
 int vips_extract_area_go(VipsImage *in, VipsImage **out, int left, int top, int width, int height);
 int vips_smartcrop_go(VipsImage *in, VipsImage **out, int width, int height);
+int vips_smartcrop_center_go(VipsImage *in, VipsImage **out, int width, int height);
 int vips_trim(VipsImage *in, VipsImage **out, double threshold,
               gboolean smart, double r, double g, double b,
               gboolean equal_hor, gboolean equal_ver);

--- a/vips.h
+++ b/vips.h
@@ -86,12 +86,14 @@ int vips_flatten_go(VipsImage *in, VipsImage **out, double r, double g, double b
 
 int vips_replicate_go(VipsImage *in, VipsImage **out, int across, int down);
 int vips_embed_go(VipsImage *in, VipsImage **out, int x, int y, int width, int height, double *bg, int bgn);
-
+int vips_embed_image_go(VipsImage *in, VipsImage *sub, VipsImage **out, int x, int y, gboolean expand);
 int vips_ensure_alpha(VipsImage *in, VipsImage **out);
 
 int vips_apply_watermark(VipsImage *in, VipsImage *watermark, VipsImage **out, double opacity);
 
 int vips_arrayjoin_go(VipsImage **in, VipsImage **out, int n);
+
+int vips_color_adjust(VipsImage *in, VipsImage **out, double scale);
 
 int vips_strip(VipsImage *in, VipsImage **out);
 


### PR DESCRIPTION
Change the `background` parameter to support either the existing color definitions (e.g. `0:0:0`) or an effect name, which only supports `blur` at the moment. The `blur` effect uses a blurred, darkened, and blown up version of the image to fill unused space. Tested with portrait 3:4 photo in 4:3 display as well as some random sub-zooms (below).

# 3:4 Photo, 4:3 Display

![Maniacal laughing bride twitter.com/ruth](https://user-images.githubusercontent.com/33917/165848290-7eb0571e-a01b-49ec-b3c1-fcecb0f904ab.jpg)

# Random Subzoom

![26B145D8-27B4-4850-9951-E21A8E4C665F-1](https://user-images.githubusercontent.com/33917/165848561-9dc38cc7-52f8-485e-928e-70c604ec2c16.jpg)

