### PR TITLE
Background Blur: Tune the blur factor to better handle faces

### DIFF
--- a/process.go
+++ b/process.go
@@ -573,7 +573,7 @@ func transformImage(ctx context.Context, img *vipsImage, data []byte, po *proces
 				return err
 			}
 
-			if err = img.Blur(10); err != nil {
+			if err = img.Blur(40); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Worked with Gino on the blur and darkening values. When displaying images with faces the existing blur of 10 was not enough and it resulted in creepy eyes in the background. Moved the blur to 40 to obscure those. If we need to fine tune more I'll refactor it into a parameter but pretty sure this will work.