### PR TITLE
fix band error when bluring pngs with alpha channels

### DIFF
--- a/processing_options.go
+++ b/processing_options.go
@@ -728,10 +728,8 @@ func applyBackgroundOption(po *processingOptions, args []string) error {
 			po.Flatten = true
 			po.Background.Color = c
 		} else if args[0] == "blur" {
-			po.Flatten = true
+			po.Flatten = false
 			po.Background.Effect = "blur"
-			// Test hack
-			po.Background.Color = rgbColor{255, 0, 0}
 		} else {
 			return fmt.Errorf("Invalid background argument: %s", err)
 		}

--- a/vips.go
+++ b/vips.go
@@ -685,6 +685,13 @@ func (img *vipsImage) CopyMemory() error {
 	return nil
 }
 
+func (img *vipsImage) CopyTo(destImg *vipsImage) error {
+	if C.vips_copy_go(img.VipsImage, &destImg.VipsImage) != 0 {
+		return vipsError()
+	}
+	return nil
+}
+
 func (img *vipsImage) Replicate(width, height int) error {
 	var tmp *C.VipsImage
 


### PR DESCRIPTION
Seeing a lot of these errors in production for blur urls like

```
insert: images must have the same number of bands, or one must be single-band
```

It appears to happen when PNGs are loaded with an Alpha channel. This channel would be flattened for the destination image, but re-introduced when loading the `centerImage` for compositing, causing a band mismatch.

This PR removes the `flatten` option (left for debugging?) for blur requests and uses `vips_copy` for the composite image instead of loading from raw data again
