### PR TITLE
Copies image data before sending to s3 goroutine.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Sergey Alexandrovich <darthsim@gmail.com>"
 
 RUN mkdir /imgproxy_build
 COPY . /imgproxy_build
+RUN cd /imgproxy_build; go mod tidy
 RUN cd /imgproxy_build; go build -v -o /usr/local/bin/imgproxy
 
 # ==================================================================================================


### PR DESCRIPTION
Looking through the logs to try to figure out why we would sometimes have corrupt files in S3, I found that there were tons of BadDigest errors coming from S3. When I downloaded the files cached in Cloudfront the md5 matched what was in the logs. I can't find where it is happening, but it looks like there is a race condition with the imageData slice, where something in respondWithImage is modifying the slice. 

My theory is that most of the time it is modified after the md5sum is calculated, so S3 rejects the file, but occasionally it can be modified before the md5sum is created, so S3 accepts the corrupted file data.

I made a build and put it on one imgproxy box and I haven't seen a single BadDigest log, whereas on a random other imgproxy box in the same time period I see dozens. I'll keep it in there for a few days to make sure it is stable before rolling out.

## Notion
https://www.notion.so/pushd/7c2fa13b45284797bb6f8dd3af6bdffc?v=0ae32f21fb8545648c5e5d3f19bab202&p=9d311b1a5505444298cdaaa3151b26c7&pm=s