### PR TITLE
Add hpminde_rgb option for LUT file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,8 @@ RUN cd /opt/pushd-dither \
 # decompress LUTs
 RUN cd /opt/pushd-dither/lut_dither \
     && zstd -fd --rm lab_13_hack.interpol_clarabel.npy.zst \
-    && zstd -fd --rm rgb_13.interpol_clarabel.npy.zst
+    && zstd -fd --rm rgb_13.interpol_clarabel.npy.zst \
+    && zstd -fd --rm hpminde_rgb.npy.zst
 
 # ====== END PUSHD DITHER ========
 

--- a/options/processing_options.go
+++ b/options/processing_options.go
@@ -761,6 +761,8 @@ func applyDitherOption(po *ProcessingOptions, args []string) error {
 				po.Dither.LUTFile = "lab_13_hack.interpol_clarabel"
 			case "lrgb13":
 				po.Dither.LUTFile = "rgb_13.interpol_clarabel"
+			case "hpmrgb":
+				po.Dither.LUTFile = "hpminde_rgb"
 			default:
 				if err := maybeParseNumericDitherOptions(po, arg); err != nil {
 					return err


### PR DESCRIPTION
Updates the dither submodule, which adds the hpminde_rgb files. Decompresses the LUT file in dockerfile and adds a command line option for using the hpminde_rgb files