### PR TITLE
Upstream base image update for new ios heifs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -231,7 +231,7 @@ func Reset() {
 
 	PathPrefix = ""
 
-	MaxSrcResolution = 16800000
+	MaxSrcResolution = 50000000
 	MaxSrcFileSize = 0
 	MaxAnimationFrames = 1
 	MaxAnimationFrameResolution = 0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,22 +63,24 @@ RUN /opt/pushd-dither/vendor/provision-vendored.sh
 
 # ====== END PUSHD DITHER ========
 
-
+COPY --from=build /opt/imgproxy/ /opt/imgproxy/
+COPY --from=build /usr/local/bin/imgproxy /usr/local/bin/imgproxy
 COPY docker/entrypoint.sh /usr/local/bin/
-COPY --from=build /usr/local/bin/imgproxy /usr/local/bin/
-COPY --from=build /usr/local/lib /usr/local/lib
 
 COPY NOTICE /usr/local/share/doc/imgproxy/
 
 ENV VIPS_WARNING=0
 ENV MALLOC_ARENA_MAX=2
-ENV LD_LIBRARY_PATH /usr/local/lib
+ENV FONTCONFIG_PATH /etc/fonts
 ENV IMGPROXY_MALLOC malloc
 
 RUN groupadd -r imgproxy \
   && useradd -r -u 999 -g imgproxy imgproxy \
   && mkdir -p /var/cache/fontconfig \
   && chmod 777 /var/cache/fontconfig
+
+# Disable SVE on ARM64. SVE is slower than NEON on Amazon Graviton 3
+ENV VIPS_VECTOR=167772160
 
 # run as root to allow vendored tools to run
 #USER 999

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_VERSION="v3.7.1"
+ARG BASE_IMAGE_VERSION="v3.11.0"
 
 FROM darthsim/imgproxy-base:${BASE_IMAGE_VERSION} as build
 


### PR DESCRIPTION
This updates the base image, tweaks our dockerfile, and increases the max resolution allowed (new heics ar ~15MP, imgproxy upstream is now default 50MP)

Tested with image noted at https://www.notion.so/pushd/Fix-imgproxy-for-new-iOS-images-11a8ff3a891d809cb923c9bb42e15ed6?pvs=4