### PR TITLE
Fix background blur with alpha channel images

### DIFF
--- a/processing/padding.go
+++ b/processing/padding.go
@@ -108,6 +108,13 @@ func padding(pctx *pipelineContext, img *vips.Image, po *options.ProcessingOptio
 		// looks bad.
 		outputScale *= 1.1
 
+		if img.HasAlpha() {
+			// images need to have the same number of channels before EmbedImage below
+			if err := img.Flatten(vips.Color{}); err != nil {
+				return err
+			}
+		}
+
 		if err := img.OldResize(outputScale, false); err != nil {
 			return err
 		}


### PR DESCRIPTION
remove alpha channel if present before compositing background blur to avoid

```
ierrors.Error:  insert: images must have the same number of bands, or one must be single-band
```

this is our number one issue on airbrake and seems like a small fix https://pushd.airbrake.io/projects/325156/groups/3660977408466635760?tab=overview