### PR TITLE
Dither using jpeg not png to avoid odd coloring

### DIFF
--- a/processing/dither.go
+++ b/processing/dither.go
@@ -37,7 +37,7 @@ func dither(pctx *pipelineContext, img *vips.Image, po *options.ProcessingOption
 	}
 
 	// create empty temp file
-	f, err := os.CreateTemp("", "dither*.png")
+	f, err := os.CreateTemp("", "dither*.jpeg")
 	if err != nil {
 		return err
 	}
@@ -54,13 +54,13 @@ func dither(pctx *pipelineContext, img *vips.Image, po *options.ProcessingOption
 		return err
 	}
 
-	pngData, err := img.Save(imagetype.PNG, 0)
+	jpgData, err := img.Save(imagetype.JPEG, 0)
 	if err != nil {
 		return err
 	}
-	defer pngData.Close()
+	defer jpgData.Close()
 
-	if err = os.WriteFile(f.Name(), pngData.Data, 0644); err != nil {
+	if err = os.WriteFile(f.Name(), jpgData.Data, 0644); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
For some reason when imgproxy converts a source image from heic to png prior to invoking the dither test.py, the resulting image is much more muted and yellow than expected when running the image locally. 

Working around this by converting from source -> jpg before invoking the dither test.py, which does the trick.

This may have something to do with the PNG options used by default https://github.com/pushd/imgproxy/blob/44fdf487dbd72070a9a5741654580e37ba47a9e9/vips/vips.go#L372-L376