### PR TITLE
Workaround odd coloring when dithering with png intermediate format

### DIFF
--- a/processing/dither.go
+++ b/processing/dither.go
@@ -2,6 +2,7 @@ package processing
 
 import (
 	"fmt"
+	"github.com/imgproxy/imgproxy/v3/security"
 	"math"
 	"os"
 	"os/exec"
@@ -9,7 +10,6 @@ import (
 	"github.com/imgproxy/imgproxy/v3/imagedata"
 	"github.com/imgproxy/imgproxy/v3/imagetype"
 	"github.com/imgproxy/imgproxy/v3/options"
-	"github.com/imgproxy/imgproxy/v3/security"
 	"github.com/imgproxy/imgproxy/v3/vips"
 	log "github.com/sirupsen/logrus"
 )
@@ -54,7 +54,8 @@ func dither(pctx *pipelineContext, img *vips.Image, po *options.ProcessingOption
 		return err
 	}
 
-	pngData, err := img.Save(imagetype.PNG, 0)
+	// standard img.Save(imagetype.PNG ...) is lossy and colors are not preserved
+	pngData, err := img.SaveHighQualityPNG()
 	if err != nil {
 		return err
 	}

--- a/processing/dither.go
+++ b/processing/dither.go
@@ -2,7 +2,6 @@ package processing
 
 import (
 	"fmt"
-	"github.com/imgproxy/imgproxy/v3/security"
 	"math"
 	"os"
 	"os/exec"
@@ -10,6 +9,7 @@ import (
 	"github.com/imgproxy/imgproxy/v3/imagedata"
 	"github.com/imgproxy/imgproxy/v3/imagetype"
 	"github.com/imgproxy/imgproxy/v3/options"
+	"github.com/imgproxy/imgproxy/v3/security"
 	"github.com/imgproxy/imgproxy/v3/vips"
 	log "github.com/sirupsen/logrus"
 )

--- a/vips/vips.c
+++ b/vips/vips.c
@@ -847,6 +847,15 @@ vips_jpegsave_go(VipsImage *in, void **buf, size_t *len, int quality, int interl
   );
 }
 
+
+int
+vips_pngsave_hq_go(VipsImage *in, void **buf, size_t *len) {
+  return vips_pngsave_buffer(in, buf, len,
+    "compression", 0,
+    NULL
+  );
+}
+
 int
 vips_pngsave_go(VipsImage *in, void **buf, size_t *len, int interlace, int quantize, int colors) {
   int bitdepth;

--- a/vips/vips.c
+++ b/vips/vips.c
@@ -851,7 +851,6 @@ vips_jpegsave_go(VipsImage *in, void **buf, size_t *len, int quality, int interl
 int
 vips_pngsave_hq_go(VipsImage *in, void **buf, size_t *len) {
   return vips_pngsave_buffer(in, buf, len,
-    "compression", 0,
     NULL
   );
 }

--- a/vips/vips.h
+++ b/vips/vips.h
@@ -92,6 +92,7 @@ int vips_color_adjust(VipsImage *in, VipsImage **out, double scale);
 int vips_strip(VipsImage *in, VipsImage **out, int keep_exif_copyright);
 
 int vips_jpegsave_go(VipsImage *in, void **buf, size_t *len, int quality, int interlace);
+int vips_pngsave_hq_go(VipsImage *in, void **buf, size_t *len);
 int vips_pngsave_go(VipsImage *in, void **buf, size_t *len, int interlace, int quantize,
     int colors);
 int vips_webpsave_go(VipsImage *in, void **buf, size_t *len, int quality);


### PR DESCRIPTION
Use high quality png for intermediate dithering input

obviates #46 