### PR TITLE
Son of fixup imgproxy dithering not matching local results

### DIFF
--- a/processing/dither.go
+++ b/processing/dither.go
@@ -54,7 +54,7 @@ func dither(pctx *pipelineContext, img *vips.Image, po *options.ProcessingOption
 		return err
 	}
 
-	jpgData, err := img.Save(imagetype.JPEG, 0)
+	jpgData, err := img.Save(imagetype.JPEG, 95)
 	if err != nil {
 		return err
 	}

--- a/processing/processing.go
+++ b/processing/processing.go
@@ -35,8 +35,8 @@ var mainPipeline = pipeline{
 	fixSize,
 	flatten,
 	watermark,
-	dither,
 	exportColorProfile,
+	dither,
 	stripMetadata,
 }
 


### PR DESCRIPTION
The `exportColorProfile` stage in the imgproxy pipeline, which is repsonsible for embedded profile -> sRGB transformation, was happening after dithering.

Moved this to happen before dithering, producing a proper sRGB (not say Display P3) intermediate file for test.py to ingest.

