### PR TITLE
FRAM-103 Fix image stretching/squishing on Ink frame

### DIFF
--- a/options/processing_options.go
+++ b/options/processing_options.go
@@ -1247,6 +1247,16 @@ func applyURLOptions(po *ProcessingOptions, options urlOptions) error {
 		}
 	}
 
+	// If dithering is enabled, apply these options to ensure the resulting image exactly matches the expected size.
+	if po.Dither.Type != DitherNone {
+		po.ResizingType = ResizeFit
+		po.Flatten = true
+		po.Background.Color = vips.Color{R: 0, G: 0, B: 0} // default black background
+		po.Enlarge = true
+		po.Extend.Enabled = true
+		po.Padding.Enabled = false
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
[FRAM-103](https://www.notion.so/pushd/Images-are-stretching-on-Frame-Images-from-backend-don-t-match-requested-dimensions-21c8ff3a891d808b94efd57a1890224d?v=22d8ff3a891d80559def000c9bc3e01c&source=copy_link)

I'm a little nervous about the change I've proposed here since it creates some implicit behavior that overrides some parameters if the dithering parameter is present.  My mantra is "Explicit is better than implicit".  If we don't want to change the URL generation in pushd-web, should we add a new parameter here like `eink_overrides` that make the behavior a little more explicit and less surprising?

I tested this by running imgproxy locally in docker like this:
```
docker run --name imgproxy -p 8080:8080 -e PUSH_S3_IMAGES_BUCKET=none -e PUSH_S3_RENDER_BUCKET=none -e IMGPROXY_USE_LOCAL="true" -e IMGPROXY_ALLOW_LOOPBACK_SOURCE_ADDRESSES=true -it imgproxy
```

And then I used URLs that pointed it to images running on a local simple HTTP server (i.e. `python3 -m http.server 8080`), with URLs like this:

```
http://localhost:8080/unsafe/rotate:0/width:1600/height:1200/rt:fit/dither:fs:opts05:w:61.02:-3.68:-2.42:r:24.26:39.62:29.22:g:31.12:-20.86:3.19:bk:9.37:9.19:-14.07:bl:27.85:5.29:-37.79:y:60.14:-11.6:63.22/padding:0:150:0:150/background:0:0:0/crop:472:436:nowe:0:16/plain/http://10.4.4.22:8000/IMG_0916.jpg?cs=srgb&w=1600&h=1200
```

| Before | After |
| - | - |
| <img width="1600" height="1200" alt="before" src="https://github.com/user-attachments/assets/63e2da0c-0f27-4b12-be55-59946e7f9509" /> | <img width="1600" height="1200" alt="after_stretchfix" src="https://github.com/user-attachments/assets/5ef89f6c-7af7-4ce0-a883-004ece385a4a" /> |
| <img width="1600" height="1200" alt="before2" src="https://github.com/user-attachments/assets/a2cc339a-fa20-41d2-8760-c7e853d2e102" /> | <img width="1600" height="1200" alt="after_stretchfix2" src="https://github.com/user-attachments/assets/81df554d-8d7a-41c0-97ac-c72e0e5a55b7" /> |