### PR TITLE
FRAM-134 The black bars are dithered.  They should be solid.

### DIFF
--- a/processing/processing.go
+++ b/processing/processing.go
@@ -29,6 +29,7 @@ var mainPipeline = pipeline{
 	rotateAndFlip,
 	cropToResult,
 	applyFilters,
+	dither,
 	extend,
 	extendAspectRatio,
 	padding,
@@ -36,7 +37,6 @@ var mainPipeline = pipeline{
 	flatten,
 	watermark,
 	exportColorProfile,
-	dither,
 	stripMetadata,
 }
 


### PR DESCRIPTION
[FRAM-134](https://www.notion.so/pushd/The-black-bars-are-dithered-They-should-be-solid-22c8ff3a891d805c9cdcdac57832b2e8?v=22d8ff3a891d80559def000c9bc3e01c&source=copy_link)

I tested this by running imgproxy locally in docker like this:
```
docker run --name imgproxy -p 8080:8080 -e PUSH_S3_IMAGES_BUCKET=none -e PUSH_S3_RENDER_BUCKET=none -e IMGPROXY_USE_LOCAL="true" -e IMGPROXY_ALLOW_LOOPBACK_SOURCE_ADDRESSES=true -it imgproxy
```

And then I used URLs that pointed it to images running on a local simple HTTP server (i.e. `python3 -m http.server 8080`), with URLs like this:

```
http://localhost:8080/unsafe/rotate:0/width:1600/height:1200/rt:fit/dither:fs:opts05:w:61.02:-3.68:-2.42:r:24.26:39.62:29.22:g:31.12:-20.86:3.19:bk:9.37:9.19:-14.07:bl:27.85:5.29:-37.79:y:60.14:-11.6:63.22/padding:0:150:0:150/background:0:0:0/crop:472:436:nowe:0:16/plain/http://10.4.4.22:8000/IMG_0916.jpg?cs=srgb&w=1600&h=1200
```

| Before | After |
| - | - |
| <img width="1600" height="1200" alt="before" src="https://github.com/user-attachments/assets/63e2da0c-0f27-4b12-be55-59946e7f9509" /> | <img width="1599" height="1200" alt="after" src="https://github.com/user-attachments/assets/63e14395-55fb-473b-aa9a-1d49da41db7a" /> |