### PR TITLE
FRAM-134 FRAM-103 Fix stretched images and dithered black bars for Ink frame.

### DIFF
--- a/options/processing_options.go
+++ b/options/processing_options.go
@@ -1247,6 +1247,14 @@ func applyURLOptions(po *ProcessingOptions, options urlOptions) error {
 		}
 	}
 
+	// If dithering is enabled, we need to disable extending and padding
+	// so we don't end up with dithered black bars.  The
+	// extension of the image will happen at the end of the dithering step.
+	if po.Dither.Type != DitherNone {
+		po.Extend.Enabled = false
+		po.Padding.Enabled = false
+	}
+
 	return nil
 }
 

--- a/processing/dither.go
+++ b/processing/dither.go
@@ -97,6 +97,15 @@ func dither(pctx *pipelineContext, img *vips.Image, po *options.ProcessingOption
 	// force lossless output
 	po.Format = imagetype.PNG
 
+	// if the image is smaller than the requested size, we need to extend it with black background
+	if err := extendImage(img, po.Width, po.Height, &options.ExtendOptions{Enabled: true}, pctx.dprScale, false); err != nil {
+		return err
+	}
+
+	if err := img.Flatten(vips.Color{R: 0, G: 0, B: 0}); err != nil {
+		return err
+	}
+
 	// the resulting images are occasionally corrupted if we don't invoke CopyMemory once we're done
 	return img.CopyMemory()
 }


### PR DESCRIPTION
Supercedes #51 and #52, with the approach suggested in the comments there.  This moves the special resizing of images for Ink to the end of the dithering step.  This ensures that the resulting image is the right size, and that any black bars added to extend the image are not dithered and snowy.

I tested this by running imgproxy locally in docker like this:
```
docker run --name imgproxy -p 8080:8080 -e PUSH_S3_IMAGES_BUCKET=none -e PUSH_S3_RENDER_BUCKET=none -e IMGPROXY_USE_LOCAL="true" -e IMGPROXY_ALLOW_LOOPBACK_SOURCE_ADDRESSES=true -it imgproxy
```

And then I used URLs that pointed it to images running on a local simple HTTP server (i.e. `python3 -m http.server 8080`), with URLs like this:

```
http://localhost:8080/unsafe/rotate:0/width:1600/height:1200/rt:fit/dither:fs:opts05:w:61.02:-3.68:-2.42:r:24.26:39.62:29.22:g:31.12:-20.86:3.19:bk:9.37:9.19:-14.07:bl:27.85:5.29:-37.79:y:60.14:-11.6:63.22/padding:0:150:0:150/background:0:0:0/crop:472:436:nowe:0:16/plain/http://10.4.4.22:8000/IMG_0916.jpg?cs=srgb&w=1600&h=1200
```

| Before | After |
| - | - |
| <img width="1600" height="1200" alt="before" src="https://github.com/user-attachments/assets/63e2da0c-0f27-4b12-be55-59946e7f9509" /> | <img width="1600" height="1200" alt="after_post_dither" src="https://github.com/user-attachments/assets/7b70090d-6802-4805-aeff-8d5ec292a99a" /> |
| <img width="1600" height="1200" alt="before2" src="https://github.com/user-attachments/assets/a2cc339a-fa20-41d2-8760-c7e853d2e102" /> | <img width="1600" height="1200" alt="after_post_dither2" src="https://github.com/user-attachments/assets/afb946ec-16df-4cb9-8ac9-32008253ca25" /> |