### PR TITLE
pin to bookworm to fix part of the build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,9 +43,13 @@ RUN apt-get update \
       curl \
       zstd \
       build-essential \
-      cmake
+      cmake \
+      git
 
-RUN pip3 install scikit-image==0.22.0 scipy==1.11.4 opencv-python numpy Pillow dlib==19.24.4 pyamg --break-system-packages
+RUN pip3 install scikit-image==0.22.0 scipy==1.11.4 opencv-python numpy Pillow dlib==19.24.4 --break-system-packages
+
+# https://pushd.slack.com/archives/C07A4MNKDE2/p1755641040891479?thread_ts=1755542357.600459&cid=C07A4MNKDE2
+RUN pip3 install git+https://github.com/pyamg/pyamg.git@5e0224e2881faf93a9e62783a212e346d2979460 --break-system-packages
 
 COPY plugins/pushd-dither /opt/pushd-dither/
 


### PR DESCRIPTION
Since debian 13 Trixie became stable on 2025-08-09, builds were failing with "Unable to locate package libpcre3" so this pins it back to bookworm until we decide to update dependencies.  

However builds still fail on dlib==19.24.4:

108.7       [100%] Linking CXX shared module /tmp/pip-install-d_g9vonj/dlib_3290ea725ee64fac880094072fa2ce43/build/lib.linux-x86_64-cpython-311/_dlib_pybind11.cpython-311-x86_64-linux-gnu.so
108.7       In member function ‘allocate_array’,
108.7           inlined from ‘set_max_size.constprop’ at /tmp/pip-install-d_g9vonj/dlib_3290ea725ee64fac880094072fa2ce43/dlib/../dlib/matrix/../array/array_kernel.h:438:59:
108.7       /tmp/pip-install-d_g9vonj/dlib_3290ea725ee64fac880094072fa2ce43/dlib/../dlib/memory_manager_stateless/memory_manager_stateless_kernel_1.h:54:24: warning: argument 1 value ‘18446744073709551615’ exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
108.7          54 |                 return new T[size];
108.7             |                        ^
108.7       /usr/include/c++/12/new: In member function ‘set_max_size.constprop’:
108.7       /usr/include/c++/12/new:128:26: note: in a call to allocation function ‘operator new []’ declared here
108.7         128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
108.7             |                          ^

But it sounds like maybe this is a pre-existing cross-compilation issue have we been doing these builds from a linux host?  
https://github.com/davisking/dlib/issues/3038#issuecomment-2565555244
