### PR TITLE
fix pyamg more

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update \
 RUN pip3 install scikit-image==0.22.0 scipy==1.11.4 opencv-python numpy Pillow dlib==19.24.4 --break-system-packages
 
 # https://pushd.slack.com/archives/C07A4MNKDE2/p1755641040891479?thread_ts=1755542357.600459&cid=C07A4MNKDE2
-RUN pip3 install git+https://github.com/pyamg/pyamg.git@5e0224e2881faf93a9e62783a212e346d2979460 --break-system-packages
+RUN pip3 install git+https://github.com/pushd/pyamg.git@v5.2.0_with_pinned_scm --break-system-packages
 
 COPY plugins/pushd-dither /opt/pushd-dither/
 


### PR DESCRIPTION
use forked pyamg with pinning scm fix from https://github.com/pushd/imgproxy/pull/54 but based on 5.2.0 instead of 5.2.1 which requires scipy somewhere between >11 <15 but i couldn't get to work.  this can actually produce dither output whereas the last commit got stuck on https://pushd.slack.com/archives/C07A4MNKDE2/p1755696925276799?thread_ts=1755542357.600459&cid=C07A4MNKDE2 because we're pinned on scipy 11

per https://github.com/pushd/pushd-dither/commit/6d49bc9dd7ed76f8f0da2e3dc3f3e193752cbbdc