### PR TITLE
(re)build libheif with X265 encoder instead of kvazaar

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,34 @@ ARG TARGETPLATFORM
 COPY . .
 RUN docker/build.sh
 
+#===== proper libheif ======
+
+# Install x265 build dependency
+RUN apt-get update && apt-get install -y \
+    ninja-build cmake git curl libx265-dev nasm libde265-dev
+
+# Rebuild libheif with x265 instead of kvazaar
+RUN git clone --depth 1 --branch v1.21.2 https://github.com/strukturag/libheif.git /tmp/libheif \
+    && cd /tmp/libheif \
+    && curl -Ls https://github.com/DarthSim/libheif/commit/d63ec62d93ab1420c8cf76378af2a806aeb5292d.patch | git apply \
+    && mkdir _build && cd _build \
+    && CFLAGS="-O3" CXXFLAGS="-O3" cmake \
+        -G"Ninja" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/opt/imgproxy \
+        --preset=release-noplugins \
+        -DBUILD_SHARED_LIBS=1 \
+        -DWITH_EXAMPLES=0 \
+        -DWITH_KVAZAAR=0 \
+        -DWITH_X265=1 \
+        -DWITH_DAV1D=1 \
+        -DWITH_DAV1D_PLUGIN=0 \
+        -DWITH_AOM_DECODER=0 \
+        -DWITH_AOM_ENCODER=0 \
+        .. \
+    && ninja install/strip \
+    && rm -rf /tmp/libheif
+
 # ==================================================================================================
 # Final image
 


### PR DESCRIPTION
imgproxy is generating larger-than-expected heif images, with the wrong profile

imgproxy builds its own libheif, and uses something called the kvazaar library to encode. This causes heics to be encoded as large-ish videos of one frame with the `Main` HEVC profile , instead of using the `Main Still Picture` HEVC profile

The base image builds the libheif:

https://github.com/imgproxy/imgproxy-docker-base/blob/9095a2cbb6128571fd4e047f1175db1881302954/build-deps.sh#L317-L328

Not sure if re-building it like this is more or less maintainable than forking the base image too, but modifying the compile options seems to do the trick - generating proper heic files